### PR TITLE
Pushy pushy

### DIFF
--- a/candidate-questions/src/main/java/com/outreach/interviews/map/builder/MapRoutesHelper.java
+++ b/candidate-questions/src/main/java/com/outreach/interviews/map/builder/MapRoutesHelper.java
@@ -80,8 +80,6 @@ public class MapRoutesHelper
 		 * @return {@link RoutesBuilder}
 		 */
 		public RoutesBuilder setURL(MapOperations type) {
-			if(type.equals(MapOperations.geocode))
-				throw new UnsupportedOperationException();
 
 			this.operation = type;
 			return this;
@@ -96,10 +94,18 @@ public class MapRoutesHelper
 		 * @throws IllegalArgumentException Thrown to indicate that a method has been passed an illegal orinappropriate argument.
 		 */
 		public RoutesBuilder build() throws UnsupportedOperationException, IOException, IllegalArgumentException {
-			String requestURL = this.getURL()  	+ "&origin=" + getOrigin() 
-												+ "&destination=" + getDestination()
-												+ "&region=" + getRegion()
-												+ "&key=" + this.getAPIKey();
+			String requestURL = "";
+			if (this.operation.equals(MapOperations.directions)) {
+				requestURL = this.getURL()  	+ "&origin=" + getOrigin() 
+													+ "&destination=" + getDestination()
+													+ "&region=" + getRegion()
+													+ "&key=" + this.getAPIKey();
+				
+			} else if (this.operation.equals(MapOperations.geocode)) {
+				requestURL = this.getURL()  	+ "&address=" + getOrigin() 
+													+ "&region=" + getRegion()
+													+ "&key=" + this.getAPIKey();
+			}
 			
 			if(getMode() != null) {
 				requestURL = requestURL + "&mode=" + this.getMode();
@@ -143,6 +149,20 @@ public class MapRoutesHelper
 			}
 		}
 		
+		
+		/**
+		 * Retrieve the geocodes of a location. Uses the origin of the RoutesBuilder object 
+		 * as the location to fetch geocodes
+		 * @return A JSON object {"lat": x, "lng": y} where x and y are the latitude and longitude
+		 */
+		public JsonObject getGeocodes() {
+			if(this.operation.equals(MapOperations.geocode) && zeroResults(this.result)) {
+				return this.result.get("results").getAsJsonArray().get(0).getAsJsonObject()
+						.get("geometry").getAsJsonObject().get("location").getAsJsonObject();
+			} else {
+				throw new IllegalArgumentException("Does not support " + MapOperations.directions.name());
+			}
+		}
 
 		//*************************For Internal Use Only***********************************//
 		private final String getURL() {
@@ -150,7 +170,7 @@ public class MapRoutesHelper
 		}
 
 		private final String getAPIKey() {
-			return System.getenv("OUTREACH_MAPS_KEY");
+			return "AIzaSyCeAwfoBGXTIcsYP9CLtvrrUO5x1vG3hfQ";
 		}
 		
 		private final String getOrigin() {
@@ -176,7 +196,7 @@ public class MapRoutesHelper
 		}
 		
 		private final String getRegion() {
-			if(this.destination == null)
+			if(this.region == null)
 				throw new IllegalArgumentException("Region cannot be empty");
 			
 			return this.region.name();

--- a/candidate-questions/src/test/java/com/outreach/interviews/TestMapRoutesHelper.java
+++ b/candidate-questions/src/test/java/com/outreach/interviews/TestMapRoutesHelper.java
@@ -1,5 +1,6 @@
 package com.outreach.interviews;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -8,6 +9,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import com.google.gson.JsonObject;
 import com.outreach.interviews.map.builder.MapRoutesHelper;
 import com.outreach.interviews.map.enums.MapOperations;
 import com.outreach.interviews.map.enums.MapRegions;
@@ -39,18 +41,6 @@ public class TestMapRoutesHelper
 		assertTrue(steps.size() > 5);
 	}
 	
-	@Test(expected = java.lang.UnsupportedOperationException.class)
-	public void testMapRoutesHelperApiKey3() throws UnsupportedOperationException, IOException {
-		List<String> steps = new MapRoutesHelper.RoutesBuilder()
-			.setOrigin("Sudbury")
-			.setDestination("Ottawa")
-			.setRegion(MapRegions.en)
-			.setURL(MapOperations.geocode)
-			.build()
-			.getDirections();
-		
-		assertNotNull(steps);
-	}
 	
 	@Test(expected = java.lang.IllegalArgumentException.class)
 	public void testMapRoutesHelperApiKey4() throws UnsupportedOperationException, IOException {
@@ -75,6 +65,34 @@ public class TestMapRoutesHelper
 			.getDirections();
 		
 		assertNotNull(steps);
+	}
+	
+	@Test
+	public void testMapGeocode() throws UnsupportedOperationException, IOException {
+		JsonObject geocodes = new MapRoutesHelper.RoutesBuilder()
+				.setOrigin("Sudbury")
+				.setRegion(MapRegions.en)
+				.setURL(MapOperations.geocode)
+				.build()
+				.getGeocodes();
+		
+		assertNotNull(geocodes);
+		assertEquals(46.4917317, geocodes.get("lat").getAsDouble(), 0.1);
+		assertEquals(-80.9930299, geocodes.get("lng").getAsDouble(), 0.1);
+	}
+	
+	@Test
+	public void testMapGeocode2() throws UnsupportedOperationException, IOException {
+		JsonObject geocodes = new MapRoutesHelper.RoutesBuilder()
+				.setOrigin("Ottawa")
+				.setRegion(MapRegions.en)
+				.setURL(MapOperations.geocode)
+				.build()
+				.getGeocodes();
+		
+		assertNotNull(geocodes);
+		assertEquals(45.4215296, geocodes.get("lat").getAsDouble(), 0.1);
+		assertEquals(-75.6971931, geocodes.get("lng").getAsDouble(), 0.1);
 	}
 	
 }


### PR DESCRIPTION
## Purpose
Add ability to get geocodes using RoutesBuilder

## Acceptance Criteria
- [ ] The user should be able to get a JsonObject in the form {"lat": x, "lng": y}, where x is the latitude and y is the longitude of a location

## Additional Notes
Stopgap hijacking
